### PR TITLE
arbitrary-file-write/file-delete: Add FreeBSD specific

### DIFF
--- a/arbitrary-file-write/file-delete/README.md
+++ b/arbitrary-file-write/file-delete/README.md
@@ -12,6 +12,8 @@
 
 ### FreeBSD
 
+`${LOCALBASE}` is the path where ports and packages are installed on the system. By default it is `/usr/local`.
+
 * `rm /etc/spwd.db`
 	* system broken. tested: `passwd, sudo, login, su`
 	* system also broken after reboot. tested: `login`
@@ -21,3 +23,5 @@
 	* only `passwd` broken. still broken after reboot
 * `rm /etc/group`
 	* `passwd, sudo, login, su` keep working as expected, even after reboot
+* `rm ${LOCALBASE}/etc/sudoers`
+	* only `sudo` broken (also tested empty file). still broken after reboot

--- a/arbitrary-file-write/file-delete/README.md
+++ b/arbitrary-file-write/file-delete/README.md
@@ -9,3 +9,12 @@
 	* system broken. tested: `sudo, login, su`
 * `rm /etc/sudoers`
 	* only `sudo` broken (also tested empty file)
+
+### FreeBSD
+
+* `rm /etc/spwd.db`
+	* system broken. tested: `passwd, sudo, login, su`
+* `rm /etc/master.passwd`
+	* only `passwd` broken
+* `rm /etc/pwd.db`
+	* only `passwd` broken

--- a/arbitrary-file-write/file-delete/README.md
+++ b/arbitrary-file-write/file-delete/README.md
@@ -19,3 +19,5 @@
 	* only `passwd` broken. still broken after reboot
 * `rm /etc/pwd.db`
 	* only `passwd` broken. still broken after reboot
+* `rm /etc/group`
+	* `passwd, sudo, login, su` keep working as expected, even after reboot

--- a/arbitrary-file-write/file-delete/README.md
+++ b/arbitrary-file-write/file-delete/README.md
@@ -14,7 +14,8 @@
 
 * `rm /etc/spwd.db`
 	* system broken. tested: `passwd, sudo, login, su`
+	* system also broken after reboot. tested: `login`
 * `rm /etc/master.passwd`
-	* only `passwd` broken
+	* only `passwd` broken. still broken after reboot
 * `rm /etc/pwd.db`
-	* only `passwd` broken
+	* only `passwd` broken. still broken after reboot


### PR DESCRIPTION
FreeBSD does not have /etc/shadow. So I have tested /etc/master.passwd, /etc/pwd.db and /etc/spwd.db.

I have created a FreeBSD subsection in the Test Notes section. I am not sure this is the best way to do it: when the repository grows we will probably have resources specific to different operating systems, different linux distributions, different linux kernels etc. I fear this will become messy quickly.

Two different ideas to fix the issue:
- use different directories and files for different software and versions, as you have already suggested in https://github.com/LiveOverflow/security-research/pull/1#issuecomment-1201008257 . It has the advantage that you can do everything with .md files, immediately readable on the GitHub website;
- be format agnostic and focus on data by using xml: this would give us more flexibility and we could change our mind on the repository structure more easily as it grows; moreover, this would also allow us to organize our data in multiple format if we wanted (e.g. we could create tools to generate  an md version, an asciiDoc version, an html version, a pdf version etc.)

Please let me know if I have to fix anything in my pull request.